### PR TITLE
Download a specific version instead of the latest version

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ import cachedir from "cachedir";
 
 const REPO = "Shopify/function-runner";
 const NAME = "function-runner";
-const VERSION = "v5.1.3";
+const VERSION = "v5.1.4";
 
 async function main() {
   if (!(await isBinaryDownloaded(VERSION))) {


### PR DESCRIPTION
The current behaviour of downloading the latest released version automatically and not using a fixed version means it isn't possible to safely make a breaking change to the command line interface if this package is being invoked through `npm exec` or `npx`. So change it to download a specific version.